### PR TITLE
Accès dynamique au serveur

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -1,0 +1,4 @@
+<server_param>
+	<ip>127.0.0.1</ip>
+	<port>12345</port>
+</server_param>

--- a/include/client.h
+++ b/include/client.h
@@ -1,2 +1,5 @@
 int sock;
+char *ipaddr;
+char *port;
+int parse_config_file(const char *xmlfile);
 int send_data(int sock2server, const char* data2send, ...);

--- a/src/client/client.c
+++ b/src/client/client.c
@@ -34,7 +34,6 @@ int parse_config_file(const char *xmlfile){
 		xmlCleanupParser();
 		debug("%s\n", ipaddr);
 		debug("%s\n", port);
-		debug("%s\n", bin2run);
 	}
 
 	return 0;

--- a/src/client/client.c
+++ b/src/client/client.c
@@ -2,12 +2,43 @@
 #include <unistd.h>
 #include <string.h>
 #include <stdarg.h>
+#include <errno.h>
 /* local headers */
 #include <include/client.h>
+#include <include/client_tool.h>
+#include <include/common.h>
 
 #define STRING_LEN 2048
 
 static FILE* info = NULL;
+
+int parse_config_file(const char *xmlfile){
+
+	if (xmlfile == NULL || access(xmlfile, F_OK) == -1)
+	{
+		fprintf(stderr, "%s : %s\n", xmlfile, strerror(errno));
+		return -1;
+	} else {
+		xmlDoc *doc = NULL;
+		xmlNode *root_element = NULL;
+		doc = xmlReadFile(xmlfile, NULL, 0);
+
+		if (doc == NULL) {
+			printf("Could not parse the XML file");
+			return -2;
+		}
+
+		root_element = xmlDocGetRootElement(doc);
+		print_xml(root_element, 1);
+		xmlFreeDoc(doc);
+		xmlCleanupParser();
+		debug("%s\n", ipaddr);
+		debug("%s\n", port);
+		debug("%s\n", bin2run);
+	}
+
+	return 0;
+}
 
 int send_data(int sock2server, const char* data2send, ...){
 

--- a/src/client/main.c
+++ b/src/client/main.c
@@ -11,11 +11,14 @@
 #include <include/common.h>
 #include <include/client_tool.h>
 
+
 int main(int argc, char const *argv[]){
 
+	parse_config_file("config.xml");
+	printf("ip : %s\n", ipaddr);
+	printf("port : %s\n", port);
+
 	/* Check for IP adddr and port */
-	char *ipaddr = "127.0.0.1";
-	char *port = "12345";
 	if (init_client(0, ipaddr, port, &results) < 0){
 		exit(EXIT_FAILURE);
 	}


### PR DESCRIPTION
J'ai ajouté un fichier de configuration XML comme dans le module [client-srv](https://github.com/white-wolf-project/client-srv). Donc si on doit contacter un autre serveur, pas besoin de modifier les variables `ipaddr` et `port` puis de recompiler. Il suffit de modifier le fichier XML.

Quand @eehP va s'attaquer à la partie création du XML il un faudra moyen de modifier le `config.xml` par directement sur  `ragnarok`. 
Exemple :  `./ragnarok --server-ip 192.168.1.x --server-port 23456`