### PR TITLE
Récupération et envoie de l'adresse MAC

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -1,4 +1,5 @@
 <server_param>
 	<ip>127.0.0.1</ip>
 	<port>12345</port>
+	<iface>enp1s0</iface>
 </server_param>

--- a/include/client.h
+++ b/include/client.h
@@ -3,3 +3,4 @@ char *ipaddr;
 char *port;
 int parse_config_file(const char *xmlfile);
 int send_data(int sock2server, const char* data2send, ...);
+int get_mac(char *interface);

--- a/src/client/main.c
+++ b/src/client/main.c
@@ -17,6 +17,7 @@ int main(int argc, char const *argv[]){
 	parse_config_file("config.xml");
 	printf("ip : %s\n", ipaddr);
 	printf("port : %s\n", port);
+	printf("iface : %s\n", iface);
 
 	/* Check for IP adddr and port */
 	if (init_client(0, ipaddr, port, &results) < 0){
@@ -30,10 +31,11 @@ int main(int argc, char const *argv[]){
 		perror("connect");
 		exit(EXIT_FAILURE);
 	}
-
 	freeaddrinfo(results);
-	/*send_data(sock, data);*/
 
+	// I grab iface value in config.xml.
+	// Idea is to use config.xml instead of hardcoded values in code
+	get_mac(iface);
 	if (argc == 2)
 	{
 		run_iwlist(argv[1]); // wlo1 for Ubuntu, not sure about other distros


### PR DESCRIPTION
### Récupération et envoie de l'adresse MAC

1) Avec la fonction `get_mac` qui vient de [sysnet](https://github.com/matteyeux/sysnet) je récupère l'adresse MAC de l'interface que je veux.
2) L'interface est spécifiée dans le fichier `config.xml`. L'idée est de passer par un fichier global pour changer ce type de paramètres. Ca evitera à l'utilisateur final de recompiler le code à chaque fois.
3) On envoie l'adresse MAC via la fonction `send_data`