### PR TITLE
Python support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,10 @@ uname_s = $(shell uname -s)
 arch = $(shell arch)
 INSTALL_DIR ?= /usr/local/bin/
 
+# print python3 version
+python3v = $(shell python3 --version | cut -d . -f 2 | tr -d '\n')
+python3m = $(shell python3 --version | cut -d . -f 2 | tr -d '\n ' && echo "m")
+
 CLIENT_SRC = src/client
 SRV_SRC = src/server
 
@@ -12,8 +16,8 @@ CLIENT_SRV = client-srv
 VERSION = $(shell cat resources/control| grep Version | cut -d:  -f 2)
 DEBUG ?=
 ADV ?=
-CFLAGS = $(DBG) $(ADV) -I. -I/usr/include/libxml2/ -I$(CLIENT_SRV) -c -Wall -g -o
-LDFLAGS = -liw -lxml2
+CFLAGS = $(DBG) $(ADV) -I. -I/usr/include/libxml2/ -I/usr/include/python3.$(python3v) -I$(CLIENT_SRV) -c -Wall -g -o
+LDFLAGS = -liw -lxml2 -lpython3.$(python3m)
 CROSS_COMPILE ?=
 
 CLIENT_OBJECTS = $(CLIENT_SRC)/main.o \

--- a/include/common.h
+++ b/include/common.h
@@ -1,1 +1,2 @@
 void debug(const char* format, ...);
+int run_python(const char *pyscript);

--- a/scripts/setup_env.sh
+++ b/scripts/setup_env.sh
@@ -16,7 +16,8 @@
 sudo apt-get update && sudo apt-get upgrade -y
 
 # install build tools 
-sudo apt-get install -y make build-essential libssl-dev libreadline-dev libsqlite3-dev wget git python3 libnl-3-dev apache2 nmap m4 autoconf libtool autotools-dev libiw-dev libxml2-dev vim zsh htop
+sudo apt-get install -y make build-essential libssl-dev libreadline-dev libsqlite3-dev wget git python3 \
+libnl-3-dev apache2 nmap m4 autoconf libtool autotools-dev libiw-dev libxml2-dev vim zsh htop python3.5-dev
 
 if [[ $(arch) != "armv71" && $(arch) != "aarch64" ]];then
 	sudo apt-get install -y gcc-arm-linux-gnueabihf

--- a/src/common.c
+++ b/src/common.c
@@ -1,5 +1,6 @@
 #include <stdio.h>
 #include <stdarg.h>
+#include <Python.h>
 
 #include <include/common.h>
 
@@ -15,4 +16,17 @@ void debug(const char* format, ...)
 	vfprintf((dbg) ? dbg : stderr,format, vargs);
 	va_end(vargs);
 	#endif
+}
+
+int run_python(const char *pyscript){
+	Py_Initialize();
+	FILE* file = fopen(pyscript, "r");
+	if (file == NULL)
+	{
+		fprintf(stderr, "%s: %s\n", pyscript, strerror(errno));
+		return -2;
+	}
+	PyRun_SimpleFile(file, pyscript);
+	Py_Finalize();
+	return 0;
 }

--- a/src/python/test.py
+++ b/src/python/test.py
@@ -1,0 +1,2 @@
+#!/usr/bin/python3
+print("test")

--- a/src/server/main.c
+++ b/src/server/main.c
@@ -8,6 +8,7 @@
 
 int main(void){
 	signal(SIGINT, INThandler);
+	run_python("src/python/test.py");
 	debug("starting server...\n");
 	tcp_server("12345");
 	return 0;


### PR DESCRIPTION
Suite aux conversations de cet aprem en cours j'ai ajouté le support de Python 3.
Le prototype : `int run_python(const char *pyscript)`.

Pour exécuter un script Python il suffit d'appeler la fonction `run_python` comme ceci : 
`run_python("src/python/test.py);`

On peut voir que j'appelle cette fonction dans le code de la fonction main du serveur.
```
✗ ./ragnarok-srv
test
IP = 0.0.0.0, Port = 12345 
```
Avec : 
- mise à jour du Makefile
- Ajout de l'installation de python3.5-dev
