### PR TITLE
support XML pour le serveur

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,8 @@ OBJECTS = src/common.o
 SOURCES = $(OBJECTS:o=.c)
 
 EXTRA_OBJ = client-srv/src/client_tool.o \
-			client-srv/src/server_tool.o
+			client-srv/src/server_tool.o \
+			client-srv/src/xml.o
 
 ifeq ($(DEBUG), 1)
 	DBG = -DDEBUG

--- a/config/client.xml
+++ b/config/client.xml
@@ -1,5 +1,5 @@
-<server_param>
+<client_param>
 	<ip>127.0.0.1</ip>
 	<port>12345</port>
 	<iface>enp1s0</iface>
-</server_param>
+</client_param>

--- a/config/server.xml
+++ b/config/server.xml
@@ -1,0 +1,5 @@
+<srv_param>
+	<ip>0</ip>
+	<port>23456</port>
+	<iface>enp1s0</iface>
+</srv_param>

--- a/include/server.h
+++ b/include/server.h
@@ -1,2 +1,3 @@
 int sock;
+char *iface, *port;
 void INThandler(int sig);

--- a/src/client/client.c
+++ b/src/client/client.c
@@ -7,39 +7,11 @@
 #include <sys/ioctl.h>
 /* local headers */
 #include <include/client.h>
-#include <include/client_tool.h>
+#include <include/xml.h>
 #include <include/common.h>
-
 #define STRING_LEN 2048
 
 static FILE* info = NULL;
-
-int parse_config_file(const char *xmlfile){
-
-	if (xmlfile == NULL || access(xmlfile, F_OK) == -1)
-	{
-		fprintf(stderr, "%s : %s\n", xmlfile, strerror(errno));
-		return -1;
-	} else {
-		xmlDoc *doc = NULL;
-		xmlNode *root_element = NULL;
-		doc = xmlReadFile(xmlfile, NULL, 0);
-
-		if (doc == NULL) {
-			printf("Could not parse the XML file");
-			return -2;
-		}
-
-		root_element = xmlDocGetRootElement(doc);
-		print_xml(root_element, 1);
-		xmlFreeDoc(doc);
-		xmlCleanupParser();
-		debug("%s\n", ipaddr);
-		debug("%s\n", port);
-	}
-
-	return 0;
-}
 
 int send_data(int sock2server, const char* data2send, ...){
 
@@ -95,3 +67,4 @@ int get_mac(char *interface){
 	close(fd);
 	return 0;
 }
+

--- a/src/client/main.c
+++ b/src/client/main.c
@@ -1,3 +1,4 @@
+#include <stdlib.h>
 #include <stdio.h>
 #include <sys/types.h>
 #include <sys/socket.h>
@@ -14,7 +15,7 @@
 
 int main(int argc, char const *argv[]){
 
-	parse_config_file("config.xml");
+	parse_config_file("config/client.xml");
 	printf("ip : %s\n", ipaddr);
 	printf("port : %s\n", port);
 	printf("iface : %s\n", iface);

--- a/src/server/main.c
+++ b/src/server/main.c
@@ -5,10 +5,14 @@
 #include <include/server.h>
 #include <include/server_tool.h>
 #include <include/common.h>
+#include <include/xml.h>
 
 int main(void){
 	signal(SIGINT, INThandler);
 	debug("starting server...\n");
-	tcp_server("12345");
+	// parse file to get iface (for sysnet) and port to run server
+	parse_config_file("config/server.xml");
+	fprintf(stdout, "interface : %s\nport : %s\n", iface, port);
+	tcp_server(port);
 	return 0;
 }


### PR DESCRIPTION
On peut modifier le port du serveur sans avoir à recompiler le code.
- Mise à jour du submodule client-srv pour tout ce qui est parsing XML
- Ajout et modifications des fichiers de configuration en XML
- Suppression de la fonction `parse_config_file` puisqu'elle est maintenant dans client-srv

Le fichier XML du serveur ressemble à ça : 
```
<srv_param>
        <ip>0</ip>
        <port>23456</port>
        <iface>enp1s0</iface>
</srv_param>
```

On se fiche de la valeur de l'IP puisqu'on en a pas besoin. Il faut juste mettre le port et l'interface qui permettra d'afficher les infos du serveur, de type IP et masque avec [sysnet](https://github.com/matteyeux/sysnet)