### PR TITLE
Mise à jour du script setup_env.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ ragnarok
 ragnarok-srv
 wireless-tools
 log
+libcpuid

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ endif
 
 .PHONY : all clean $(CLIENT_SRV) $(SYSNET)
 
-all : $(CLIENT) $(SERVER)
+all : $(SERVER) $(CLIENT)
 
 $(CLIENT) : $(CLIENT_SRV) $(OBJECTS) $(CLIENT_OBJECTS)
 	@echo "LD	$@"

--- a/scripts/setup_env.sh
+++ b/scripts/setup_env.sh
@@ -13,22 +13,22 @@
 #
 
 # update repos before installing
-sudo apt-get update && sudo apt-get upgrade -y
+#sudo apt-get update && sudo apt-get upgrade -y
 
 # install build tools 
-sudo apt-get install -y make build-essential libssl-dev libreadline-dev libsqlite3-dev wget git python3 \
-libnl-3-dev apache2 nmap m4 autoconf libtool autotools-dev libiw-dev libxml2-dev vim zsh htop python3.5-dev
+#sudo apt-get install -y make build-essential libssl-dev libreadline-dev libsqlite3-dev wget git python3 \
+#libnl-3-dev apache2 nmap m4 autoconf libtool autotools-dev libiw-dev libxml2-dev vim zsh htop python3.5-dev
 
-if [[ $(arch) != "armv71" && $(arch) != "aarch64" ]];then
-	sudo apt-get install -y gcc-arm-linux-gnueabihf
-fi
+#if [[ $(arch) != "armv71" && $(arch) != "aarch64" ]];then
+#	sudo apt-get install -y gcc-arm-linux-gnueabihf
+#fi
 
 # init and clone git modules
 git submodule update --init
 
 # install git depends
-git clone https://github.com/matteyeux/sysnet; cd sysnet
-./scripts/install.sh
+git clone https://github.com/matteyeux/sysnet; cd sysnet/scripts
+./install.sh
 sudo make install
 cd ..
 

--- a/scripts/setup_env.sh
+++ b/scripts/setup_env.sh
@@ -12,25 +12,41 @@
 # Version : 0.1
 #
 
+# function to install libcpuid for sysnet
+function install_libcpuid(){
+	if [[ $(arch) == "x86_64" || $(arch) == "i686" || $(arch) == "i386" ]]; then
+		git clone https://github.com/anrieff/libcpuid.git
+		cd libcpuid
+		libtoolize
+		aclocal -I m4
+		autoreconf --install
+		ls .. && ls .
+		./configure
+		make 
+		sudo make install && cd ..
+	else 
+		echo "skipping libcpuid"
+	fi
+}
+
+
 # update repos before installing
-#sudo apt-get update && sudo apt-get upgrade -y
+sudo apt-get update && sudo apt-get upgrade -y
 
 # install build tools 
-#sudo apt-get install -y make build-essential libssl-dev libreadline-dev libsqlite3-dev wget git python3 \
-#libnl-3-dev apache2 nmap m4 autoconf libtool autotools-dev libiw-dev libxml2-dev vim zsh htop python3.5-dev
+sudo apt-get install -y make build-essential libssl-dev libreadline-dev libsqlite3-dev wget git python3 \
+libnl-3-dev apache2 nmap m4 autoconf libtool autotools-dev libiw-dev libxml2-dev vim zsh htop python3.5-dev
 
-#if [[ $(arch) != "armv71" && $(arch) != "aarch64" ]];then
-#	sudo apt-get install -y gcc-arm-linux-gnueabihf
-#fi
+if [[ $(arch) != "armv71" && $(arch) != "aarch64" ]];then
+	sudo apt-get install -y gcc-arm-linux-gnueabihf
+fi
 
 # init and clone git modules
 git submodule update --init
 
 # install sysnet
-cd sysnet/scripts
-./install.sh
-sudo make install
-cd ..
+install_libcpuid
+sudo make -C sysnet install
 
 # wireless-tools are needed for iwlist.c in our project
 git clone https://github.com/white-wolf-project/wireless-tools.git

--- a/scripts/setup_env.sh
+++ b/scripts/setup_env.sh
@@ -26,14 +26,11 @@
 # init and clone git modules
 git submodule update --init
 
-# install git depends
-git clone https://github.com/matteyeux/sysnet; cd sysnet/scripts
+# install sysnet
+cd sysnet/scripts
 ./install.sh
 sudo make install
 cd ..
-
-git clone https://github.com/white-wolf-project/client-srv
-make -C client-srv
 
 # wireless-tools are needed for iwlist.c in our project
 git clone https://github.com/white-wolf-project/wireless-tools.git


### PR DESCRIPTION
J'ai remarqué que j'avais quelques erreurs de build quand je prépare l'environnement avec `setup_env.sh`.
Donc pour éviter d'utiliser le scripts de [sysnet](https://github.com/matteyeux/sysnet) pour l'installation de sysnet et libcpuid.

Ca évite d'avoir pleins de dépendances et on centralise le script.