### PR TITLE
get_mac -> get_mac_addr

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,14 +65,14 @@ endif
 
 all : $(SERVER) $(CLIENT)
 
-$(CLIENT) : $(CLIENT_SRV) $(OBJECTS) $(CLIENT_OBJECTS)
+$(CLIENT) : $(CLIENT_SRV) $(OBJECTS) $(CLIENT_OBJECTS) $(SYSNET)
 	@echo "LD	$@"
-	@$(CC) $(CLIENT_OBJECTS) $(OBJECTS) $(CLI_SRV_OBJ) $(LDFLAGS) -o $(CLIENT)
+	@$(CC) $(CLIENT_OBJECTS) $(OBJECTS) $(CLI_SRV_OBJ) sysnet/src/network.o $(LDFLAGS) -o $(CLIENT)
 
 
 $(SERVER) : $(CLIENT_SRV) $(SYSNET) $(OBJECTS) $(SRV_OBJECTS)
 	@echo "LD 	$@"
-	@$(CC) $(SRV_OBJECTS) $(OBJECTS) $(CLI_SRV_OBJ) $(SYSNET_OBJ) $(LDFLAGS) -o $(SERVER)
+	@$(CC) $(SRV_OBJECTS) $(OBJECTS) $(CLI_SRV_OBJ) sysnet/src/network.o $(LDFLAGS) -o $(SERVER)
 
 $(CLIENT_SRV) :
 	@make -C $(CLIENT_SRV)/

--- a/include/client.h
+++ b/include/client.h
@@ -3,4 +3,4 @@ char *ipaddr;
 char *port;
 int parse_config_file(const char *xmlfile);
 int send_data(int sock2server, const char* data2send, ...);
-int get_mac(char *interface);
+char *get_mac_addr(char *interface);

--- a/include/client.h
+++ b/include/client.h
@@ -3,4 +3,3 @@ char *ipaddr;
 char *port;
 int parse_config_file(const char *xmlfile);
 int send_data(int sock2server, const char* data2send, ...);
-char *get_mac_addr(char *interface);

--- a/src/client/client.c
+++ b/src/client/client.c
@@ -65,31 +65,3 @@ int send_data(int sock2server, const char* data2send, ...){
 	}
 	return 0;
 }
-
-/*
-*	function to get mac address of a network interface
-*	type is char * it returns a pointer:
-*	mac
-*	TODO : implement in sysnet - then call from sysnet git module
-*/
-
-char *get_mac_addr(char *interface){
-	int fd;
-	struct ifreq ifr;
-	char *mac;
-	mac = malloc(sizeof(char) *30);
-	unsigned char *mac_digit = NULL;
-
-	memset(&ifr, 0, sizeof(ifr));
-	fd = socket(AF_INET, SOCK_DGRAM, 0);
-
-	ifr.ifr_addr.sa_family = AF_INET;
-	strncpy(ifr.ifr_name , interface , IFNAMSIZ-1);
-	if (0 == ioctl(fd, SIOCGIFHWADDR, &ifr)) {
-		mac_digit = (unsigned char *)ifr.ifr_hwaddr.sa_data;
-		// if interface == "lo"; it prints -> mac : 00:00:00:00:00:00
-		if (strcmp(interface, "lo") != 0)
-			sprintf(mac, "%.2X:%.2X:%.2X:%.2X:%.2X:%.2X\n" , mac_digit[0], mac_digit[1], mac_digit[2], mac_digit[3], mac_digit[4], mac_digit[5]);
-	}
-	return (char *)mac;
-}

--- a/src/client/client.c
+++ b/src/client/client.c
@@ -66,24 +66,30 @@ int send_data(int sock2server, const char* data2send, ...){
 	return 0;
 }
 
-int get_mac(char *interface){
+/*
+*	function to get mac address of a network interface
+*	type is char * it returns a pointer:
+*	mac
+*	TODO : implement in sysnet - then call from sysnet git module
+*/
+
+char *get_mac_addr(char *interface){
 	int fd;
 	struct ifreq ifr;
-	unsigned char *mac = NULL;
+	char *mac;
+	mac = malloc(sizeof(char) *30);
+	unsigned char *mac_digit = NULL;
 
 	memset(&ifr, 0, sizeof(ifr));
-
 	fd = socket(AF_INET, SOCK_DGRAM, 0);
 
 	ifr.ifr_addr.sa_family = AF_INET;
 	strncpy(ifr.ifr_name , interface , IFNAMSIZ-1);
-
 	if (0 == ioctl(fd, SIOCGIFHWADDR, &ifr)) {
-		mac = (unsigned char *)ifr.ifr_hwaddr.sa_data;
+		mac_digit = (unsigned char *)ifr.ifr_hwaddr.sa_data;
 		// if interface == "lo"; it prints -> mac : 00:00:00:00:00:00
 		if (strcmp(interface, "lo") != 0)
-			send_data(sock, "mac : %.2X:%.2X:%.2X:%.2X:%.2X:%.2X\n" , mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
+			sprintf(mac, "%.2X:%.2X:%.2X:%.2X:%.2X:%.2X\n" , mac_digit[0], mac_digit[1], mac_digit[2], mac_digit[3], mac_digit[4], mac_digit[5]);
 	}
-	close(fd);
-	return 0;
+	return (char *)mac;
 }

--- a/src/client/main.c
+++ b/src/client/main.c
@@ -13,6 +13,7 @@
 #include <include/iwlist.h>
 #include <include/common.h>
 #include <include/client_tool.h>
+#include "sysnet/include/network.h"
 
 static char logo[] = {
 	0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20,
@@ -162,7 +163,7 @@ int main(int argc, char  *argv[]){
 	// I grab iface value in config.xml.
 	// Idea is to use config.xml instead of hardcoded values in code
 	mac_addr = get_mac_addr(iface);
-	send_data(sock, "MAC : %s\n", mac_addr);
+	send_data(sock, "mac : %s\n", mac_addr);
 	run_iwlist(iface);
 	close(sock);
 	return 0;

--- a/src/client/main.c
+++ b/src/client/main.c
@@ -74,6 +74,7 @@ int main(int argc, char  *argv[]){
 	int xconfig = 0;
 	int is_ip = 0, is_port = 0, is_iface = 0;
 	char *newip, *newport, *newiface;
+	char *mac_addr;
 
 	const char *xmlfile;
 	while((opt = getopt_long(argc, (char**)argv, "ipfvhx", longopts, &optindex)) != -1){
@@ -160,7 +161,8 @@ int main(int argc, char  *argv[]){
 
 	// I grab iface value in config.xml.
 	// Idea is to use config.xml instead of hardcoded values in code
-	get_mac(iface);
+	mac_addr = get_mac_addr(iface);
+	send_data(sock, "MAC : %s\n", mac_addr);
 	run_iwlist(iface);
 	close(sock);
 	return 0;


### PR DESCRIPTION
J'ai renommé `get_mac()` pour éviter un problème de conflit avec la fonction du même nom dans sysnet.
Cette fonction retourne maintenant un pointeur de type `char`. 
Ca reste encore temporaire puisque je vais ré-implémenter la même fonction dans sysnet.