### PR TITLE
Verification et activation de l'interface sans fils pour le scan d'AP

### DIFF
--- a/src/client/client.c
+++ b/src/client/client.c
@@ -128,40 +128,6 @@ int read_and_send_data(const char *xmlfile){
 
 /**
  * @brief
- * Up network interface it's called in print_scanning_info() like this :
- * @code
- *	if (!strcmp(strerror(errno), "Network is down"))
- *	{
- *		up_iface(ifname);
- *	} else {
- *		send_data(sock, "%-8.16s  Interface doesn't support scanning : %s\n", ifname, strerror(errno));
- *		return(-1);
- *	}
- * @endcode
- * @return returns 0 if everything's done well or -1 if we can't create a socket.
- * @see https://stackoverflow.com/questions/5858655/linux-programmatically-up-down-an-interface-kernel
- */
-int up_iface(const char *interface)
-{
-	int sockfd;
-	struct ifreq ifr;
-
-	sockfd = socket(AF_INET, SOCK_DGRAM, 0);
-
-	if (sockfd < 0)
-		return -1;
-
-	memset(&ifr, 0, sizeof ifr);
-
-	strncpy(ifr.ifr_name, interface, IFNAMSIZ);
-
-	ifr.ifr_flags |= IFF_UP;
-	ioctl(sockfd, SIOCSIFFLAGS, &ifr);
-	return 0;
-}
-
-/**
- * @brief
  * init deamon for the client
  * First we check if the pidfile exists. If it exists, it means client is already running.
  * Print pid of process the quit.

--- a/src/client/iwlist.c
+++ b/src/client/iwlist.c
@@ -573,7 +573,7 @@ static int print_scanning_info(int skfd, char *	ifname, char *	args[], int	count
 	if((!has_range) || (range.we_version_compiled < 14))
 	{
 		send_data(sock, "%-8.16s  Interface doesn't support scanning.\n\n", ifname);
-		return(-1);
+		exit(1);
 	}
 
 	/* Init timeout value -> 250ms between set and first get */
@@ -664,7 +664,7 @@ static int print_scanning_info(int skfd, char *	ifname, char *	args[], int	count
 					up_iface(ifname);
 				} else {
 					send_data(sock, "%-8.16s  Interface doesn't support scanning : %s\n", ifname, strerror(errno));
-					return(-1);
+					exit(1);
 				}
 			}
 			/* If we don't have the permission to initiate the scan, we may

--- a/src/client/main.c
+++ b/src/client/main.c
@@ -150,7 +150,7 @@ int main(int argc, char  *argv[]){
 
 	if (stop_client){
 		client_pid = get_instance_pid("ragnarok.pid");
-		/* No need to kill something that does exist*/
+		/* No need to kill something that does not exist*/
 		if (client_pid == -1)
 			return 0;
 		remove("ragnarok.pid");
@@ -199,8 +199,16 @@ int main(int argc, char  *argv[]){
 
 	if (wireless == NULL)
 	{
-		fprintf(stderr, "[e] no wireless interface found\n");
+		fprintf(stderr, "[-] no wireless interface found\n");
 		return -1;
+	} else {
+		if (is_iface_up(wireless) != true){
+			if (getuid() != 0){
+				fprintf(stderr, "[-] you need higher privileges\n");
+				return 1;
+			}
+			up_iface(wireless);
+		}
 	}
 
 	debug("ip : %s\n", ipaddr);


### PR DESCRIPTION
J'ai viré la fonction ` up_iface()` dans client.c elle est maintenant dans [sysnet](https://github.com/matteyeux/sysnet).

De plus, certains returns de `iwlist.c` sont maintenant des `exit()` pour eviter la boucle infinie inutile.

Le plus important étant qu'on peut maintenant vérifier si l'interface wireless est activée, et si elle en l'est pas, alors on l'active.
